### PR TITLE
Ingest SinkEvents as SinkingTxs

### DIFF
--- a/sc_audit/config.py
+++ b/sc_audit/config.py
@@ -33,7 +33,7 @@ DbTablePrefix = Literal["test"] | None
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix='SC_')
+    model_config = SettingsConfigDict(env_prefix='SC_', env_file=".env")
 
     DBAPI_URL: str = f"sqlite+pysqlite:///{get_default_db_path()}"
     TABLE_PREFIX: DbTablePrefix = None
@@ -49,6 +49,10 @@ class Settings(BaseSettings):
     FIRST_SINK_CURSOR: int = 164821723627237376
     FIRST_MINT_CURSOR: int = 164806777139924992
     FIRST_DIST_CURSOR: int = 164810659791396865
+
+    RETROSHADES_URL: HttpUrl = HttpUrl("https://api.mercurydata.app/retroshadesv1")
+    RETROSHADES_MD5: str = "7dcbe2731ec5ff608b526a597a2c8b78"
+    MERCURY_KEY: str = ""
 
     @computed_field
     @property

--- a/sc_audit/config.py
+++ b/sc_audit/config.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     FIRST_DIST_CURSOR: int = 164810659791396865
 
     RETROSHADES_URL: HttpUrl = HttpUrl("https://api.mercurydata.app/retroshadesv1")
-    RETROSHADES_MD5: str = "7dcbe2731ec5ff608b526a597a2c8b78"
+    RETROSHADES_MD5: str = "571c515522665c5da4d18f7ccbf8eb3a"
     MERCURY_KEY: str = ""
 
     @computed_field

--- a/sc_audit/sources/sink_events.py
+++ b/sc_audit/sources/sink_events.py
@@ -4,6 +4,7 @@ Fetch sink events from Mercury Retroshades.
 Author: Alex Olieman <https://keybase.io/alioli>
 """
 
+import datetime as dt
 from decimal import Decimal
 
 import httpx
@@ -16,7 +17,7 @@ UNIT_IN_STROOPS = 10_000_000
 
 class SinkEvent(BaseModel):
     transaction: str
-    # TODO: created_at
+    created_at: dt.datetime
     contract_id: str
     funder: str
     recipient: str
@@ -29,6 +30,7 @@ class SinkEvent(BaseModel):
     @classmethod
     def from_raw(cls, **data):
         data["amount"] = data["amount"] / UNIT_IN_STROOPS
+        data["created_at"] = dt.datetime.fromtimestamp(data["timestamp"], dt.UTC)
         return cls(**data)
 
 

--- a/sc_audit/sources/sink_events.py
+++ b/sc_audit/sources/sink_events.py
@@ -1,0 +1,60 @@
+"""
+Fetch sink events from Mercury Retroshades.
+
+Author: Alex Olieman <https://keybase.io/alioli>
+"""
+
+from decimal import Decimal
+
+import httpx
+from pydantic import BaseModel
+from stellar_sdk.sep.toid import TOID
+from sc_audit.config import settings
+
+UNIT_IN_STROOPS = 10_000_000
+
+
+class SinkEvent(BaseModel):
+    transaction: str
+    # TODO: created_at
+    contract_id: str
+    funder: str
+    recipient: str
+    amount: Decimal
+    project_id: str
+    memo_text: str | None
+    email: str | None
+    ledger: int
+
+    @classmethod
+    def from_raw(cls, **data):
+        data["amount"] = data["amount"] / UNIT_IN_STROOPS
+        return cls(**data)
+
+
+def get_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> list[SinkEvent]:
+    headers = {
+        "Authorization": settings.MERCURY_KEY,
+        "Content-Type": "application/json",
+    }
+    ledger_from_toid = TOID.from_int64(cursor).ledger_sequence
+    with httpx.Client(headers=headers) as client:
+        payload = {
+            "query": f"""
+                SELECT * FROM sink_event{settings.RETROSHADES_MD5}
+                WHERE ledger > {ledger_from_toid}
+            """
+        }
+        resp: httpx.Response = client.post(
+            url=str(settings.RETROSHADES_URL),
+            json=payload,
+        )
+        resp.raise_for_status()
+        events = resp.json()
+
+    return [SinkEvent.from_raw(**event) for event in events]
+
+
+if __name__ == "__main__":
+    sink_events = get_sink_events(cursor=0)
+    pass

--- a/tests/data_fixtures/events.py
+++ b/tests/data_fixtures/events.py
@@ -1,0 +1,125 @@
+
+query_response = """
+[
+  {
+    "funder": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
+    "recipient": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
+    "amount": 2000000,
+    "project_id": "VCS1360",
+    "memo_text": "retro",
+    "email": "acc@dom.xyz",
+    "ledger": 789012,
+    "timestamp": 1717872002,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "456807c5f6b089f1b754d78210e80cf1db9a5b58b4c1ec23558191082ac2050e"
+  },
+  {
+    "funder": "GBZXN7PIRZGNMHGA6C34KVUYYEAZHDV3BZVVU6ZYVLVDZ4JX4YXX1234",
+    "recipient": "GBR3RS2ZICQIQFWUUV3AUN7ZEMXLKJVVSWC6B2WDILOHQZB5EPII5678",
+    "amount": 500000,
+    "project_id": "VCS1370",
+    "memo_text": "offset 2024",
+    "email": "offset@example.com",
+    "ledger": 789013,
+    "timestamp": 1717872604,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "a7e2d3bbf0a44f6192c9fcd1e723a8d9fdbe0b2c24db9f228f42a9c06318f103"
+  },
+  {
+    "funder": "GCPZXW7ZL7A2YLSMRF2SH4T3KYY2L5UXMOW5JYPMOPVLSIPUXYZABCDE",
+    "recipient": "GCFYXYZ3T2L6J7OOGTH2X5MYO5WXCF7RPAKH3ABCDEF5Q66JYPLMNOP",
+    "amount": 1000000,
+    "project_id": "VCS1360",
+    "memo_text": "donation",
+    "email": "green@earth.org",
+    "ledger": 789014,
+    "timestamp": 1717873208,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "c876a4e76f1c0e3312bc7e9045d6a67f68f834fa6cd7e5ad8ec10dcf63aef15b"
+  },
+  {
+    "funder": "GDD6QX4POJXKZQXJ66R6NDKVH2UIQ7URIP7N2PBZX77TABCDEF123456",
+    "recipient": "GAXYXZJDOJZXQZ6UZZYXYABCDZUXYZXZZYXZZABCDEF1234567890001",
+    "amount": 2500000,
+    "project_id": "VCS1388",
+    "memo_text": "q2 funding",
+    "email": "investor@greenfund.com",
+    "ledger": 789015,
+    "timestamp": 1717873816,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "9f32c5075fca207d3fd9d2765dc55e4f3b8e7439425f58b8a3c45a32fa8bb02d"
+  },
+  {
+    "funder": "GBZXN7PIRZGNMHGA6C34KVUYYEAZHDV3BZVVU6ZYVLVDZ4JX4YXX4321",
+    "recipient": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
+    "amount": 750000,
+    "project_id": "VCS1361",
+    "memo_text": "tree credits",
+    "email": "forest@ngo.org",
+    "ledger": 789016,
+    "timestamp": 1717874424,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "e0b9d9d4a1d04b788f9dd3cdefdbb7e0bcb24b02778e6ab67903b8db18e3c3aa"
+  },
+  {
+    "funder": "GDUKMGUGDZQK6YHPSLR2AMNMDFY3DYUPZYPXYZABCDEFGH67890ZXCVB",
+    "recipient": "GDSRCV5VTM3U7YTW7ZXYQ5ZDA2W3FY6F7X6YXZYZYZYZYZYZXYYZZZZZ",
+    "amount": 3000000,
+    "project_id": "VCS1400",
+    "memo_text": "carbon offset",
+    "email": "climate@impact.org",
+    "ledger": 789017,
+    "timestamp": 1717875048,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "b3dcfc7f76e3ef4f1ecf1764b52894321e7a02f8a814ef310b6bfa6d3ef97f61"
+  },
+  {
+    "funder": "GAAAQ2C3HQ6W7OP4T4FD3UU6WZYZYXZYXYZZZ123456789ABCDEFEDCB",
+    "recipient": "GABCDWZYXZYXZYXZYXZYXZYXZYXYZYXZYXYZYXZYXYXYXZYXZY123456",
+    "amount": 600000,
+    "project_id": "VCS1377",
+    "memo_text": "early support",
+    "email": "early@backer.io",
+    "ledger": 789018,
+    "timestamp": 1717875600,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "af7d4d2b0f4c79cf3db7bb2f9b3a7740e134ca52e6830f2f2c19b0a8072a988f"
+  },
+  {
+    "funder": "GCPZXW7ZL7A2YLSMRF2SH4T3KYY2L5UXMOW5JYPMOPVLSIPUXYZZZZZZ",
+    "recipient": "GDFZXCZZZXZCVBNMQWERTYYUIOPASDFGHJKLZXCVBNM1234567890000",
+    "amount": 1800000,
+    "project_id": "VCS1355",
+    "memo_text": "offset tokens",
+    "email": "tokens@offsetter.net",
+    "ledger": 789018,
+    "timestamp": 1717875600,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "5c8a8d604f1369c17e315f1dfb6a3b3d1db474991215bf9d212b3fcaa54b4df9"
+  },
+  {
+    "funder": "GBHOM3QPPZ2BX7UNH2XYZXYZXYZXYZXYZXYZXYZXYZXYZXYZXYZ12345",
+    "recipient": "GBBXYZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ999",
+    "amount": 910000,
+    "project_id": "VCS1369",
+    "memo_text": "gift",
+    "email": "gift@giver.org",
+    "ledger": 789018,
+    "timestamp": 1717875600,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "1da998d2184b8e19fd63f8a36c8cc3bd1a2f4d9824ec24568706d3f7a60d8570"
+  },
+  {
+    "funder": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
+    "recipient": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
+    "amount": 100000,
+    "project_id": "VCS1360",
+    "memo_text": "testing",
+    "email": "test@mock.dev",
+    "ledger": 789018,
+    "timestamp": 1717875600,
+    "contract_id": "CBW45IZ3W5BBDIKTIXQEAOR3TAHPCFIAVQMD4NO2YPX2FA4LKGLJLWYL",
+    "transaction": "f24be6d7ef6d4ec042d73f26bc6c13506d058499db0c3e10b9a9ef33b8fd551e"
+  }
+]
+"""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,48 @@
+import datetime as dt
+from decimal import Decimal
+
+import httpx
+from httpx import Client, Response
+import pytest
+
+from sc_audit.sources.sink_events import get_sink_events
+from tests.data_fixtures.events import query_response
+
+
+class MockClient(Client):
+    def __init__(self, headers: dict) -> None:
+        assert len(headers['Authorization']) == 32
+        assert headers['Content-Type'] == "application/json"
+        super().__init__(headers=headers)
+
+    def post(self, url: str, json: dict, **kwargs) -> Response:
+        assert "retroshadesv1" in url
+        assert "query" in json
+        assert "SELECT * FROM sink_event" in json['query']
+        assert "WHERE ledger > " in json['query']
+
+        request = self.build_request(
+            method="POST",
+            url=url,
+            json=json,
+        )
+        
+        return Response(status_code=200, text=query_response, request=request)
+
+
+@pytest.fixture
+def mock_client(monkeypatch):
+    monkeypatch.setattr(httpx, "Client", MockClient)
+
+
+class TestSinkEventSources:
+    def test_events_list_full(self, mock_client):
+        events = get_sink_events(cursor=0)
+        assert len(events) == 10
+        assert events[0].amount == Decimal("0.2")
+        assert events[0].created_at == dt.datetime(2024, 6, 8, 18, 40, 2, tzinfo=dt.UTC)
+        assert events[6].amount == Decimal("0.06")
+        assert events[6].created_at == dt.datetime(2024, 6, 8, 19, 40, 0, tzinfo=dt.UTC)
+        assert events[9].amount == Decimal("0.01")
+        assert events[6].created_at == events[9].created_at
+        assert events[6].ledger == events[9].ledger


### PR DESCRIPTION
Create a source and loader for contract events (i.e. someone sinks CARBON using the Soroban contract).

The source function queries Mercury Retroshades for new events (using ledger sequence as a cursor) and represents them as intermediary `SinkEvent` objects. This takes care of basic conversions from ledger close time to `created_at` datetime and raw amount to its decimal representation.

The loader function handles the final transformation, including a `paging_token` based on TOID and filling source and dest asset fields with the CARBON asset. VCS project is validated with a fallback to the default project. Finally, the loader stores validated `SinkingTx` objects in the DB.

This way our audit tables can also include transactions conducted through Soroban.

Known limitation: tx hash is currently used as primary key, but multiple `sink_carbon` calls could be done in a single tx. We can't allow this currently and are waiting for unique event ID support from the Mercury team.