### PR TITLE
Provide an alternative for Mercury events using Obsrvr Flow extracted invocations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1208,6 +1208,107 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "psycopg"
+version = "3.2.9"
+description = "PostgreSQL database adapter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "psycopg-3.2.9-py3-none-any.whl", hash = "sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6"},
+    {file = "psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700"},
+]
+
+[package.dependencies]
+psycopg-binary = {version = "3.2.9", optional = true, markers = "implementation_name != \"pypy\" and extra == \"binary\""}
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+binary = ["psycopg-binary (==3.2.9) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.2.9) ; implementation_name != \"pypy\""]
+dev = ["ast-comments (>=1.1.2)", "black (>=24.1.0)", "codespell (>=2.2)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.14)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
+docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
+pool = ["psycopg-pool"]
+test = ["anyio (>=4.0)", "mypy (>=1.14)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.9"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "implementation_name != \"pypy\""
+files = [
+    {file = "psycopg_binary-3.2.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:528239bbf55728ba0eacbd20632342867590273a9bacedac7538ebff890f1093"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4978c01ca4c208c9d6376bd585e2c0771986b76ff7ea518f6d2b51faece75e8"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ed2bab85b505d13e66a914d0f8cdfa9475c16d3491cf81394e0748b77729af2"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:799fa1179ab8a58d1557a95df28b492874c8f4135101b55133ec9c55fc9ae9d7"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb37ac3955d19e4996c3534abfa4f23181333974963826db9e0f00731274b695"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:001e986656f7e06c273dd4104e27f4b4e0614092e544d950c7c938d822b1a894"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fa5c80d8b4cbf23f338db88a7251cef8bb4b68e0f91cf8b6ddfa93884fdbb0c1"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:39a127e0cf9b55bd4734a8008adf3e01d1fd1cb36339c6a9e2b2cbb6007c50ee"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fb7599e436b586e265bea956751453ad32eb98be6a6e694252f4691c31b16edb"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5d2c9fe14fe42b3575a0b4e09b081713e83b762c8dc38a3771dd3265f8f110e7"},
+    {file = "psycopg_binary-3.2.9-cp310-cp310-win_amd64.whl", hash = "sha256:7e4660fad2807612bb200de7262c88773c3483e85d981324b3c647176e41fdc8"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2504e9fd94eabe545d20cddcc2ff0da86ee55d76329e1ab92ecfcc6c0a8156c4"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:093a0c079dd6228a7f3c3d82b906b41964eaa062a9a8c19f45ab4984bf4e872b"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:387c87b51d72442708e7a853e7e7642717e704d59571da2f3b29e748be58c78a"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9ac10a2ebe93a102a326415b330fff7512f01a9401406896e78a81d75d6eddc"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:72fdbda5b4c2a6a72320857ef503a6589f56d46821592d4377c8c8604810342b"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f34e88940833d46108f949fdc1fcfb74d6b5ae076550cd67ab59ef47555dba95"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a3e0f89fe35cb03ff1646ab663dabf496477bab2a072315192dbaa6928862891"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6afb3e62f2a3456f2180a4eef6b03177788df7ce938036ff7f09b696d418d186"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cc19ed5c7afca3f6b298bfc35a6baa27adb2019670d15c32d0bb8f780f7d560d"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bc75f63653ce4ec764c8f8c8b0ad9423e23021e1c34a84eb5f4ecac8538a4a4a"},
+    {file = "psycopg_binary-3.2.9-cp311-cp311-win_amd64.whl", hash = "sha256:3db3ba3c470801e94836ad78bf11fd5fab22e71b0c77343a1ee95d693879937a"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:be7d650a434921a6b1ebe3fff324dbc2364393eb29d7672e638ce3e21076974e"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6a76b4722a529390683c0304501f238b365a46b1e5fb6b7249dbc0ad6fea51a0"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96a551e4683f1c307cfc3d9a05fec62c00a7264f320c9962a67a543e3ce0d8ff"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:61d0a6ceed8f08c75a395bc28cb648a81cf8dee75ba4650093ad1a24a51c8724"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad280bbd409bf598683dda82232f5215cfc5f2b1bf0854e409b4d0c44a113b1d"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76eddaf7fef1d0994e3d536ad48aa75034663d3a07f6f7e3e601105ae73aeff6"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:52e239cd66c4158e412318fbe028cd94b0ef21b0707f56dcb4bdc250ee58fd40"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:08bf9d5eabba160dd4f6ad247cf12f229cc19d2458511cab2eb9647f42fa6795"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1b2cf018168cad87580e67bdde38ff5e51511112f1ce6ce9a8336871f465c19a"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:14f64d1ac6942ff089fc7e926440f7a5ced062e2ed0949d7d2d680dc5c00e2d4"},
+    {file = "psycopg_binary-3.2.9-cp312-cp312-win_amd64.whl", hash = "sha256:7a838852e5afb6b4126f93eb409516a8c02a49b788f4df8b6469a40c2157fa21"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:98bbe35b5ad24a782c7bf267596638d78aa0e87abc7837bdac5b2a2ab954179e"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:72691a1615ebb42da8b636c5ca9f2b71f266be9e172f66209a361c175b7842c5"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25ab464bfba8c401f5536d5aa95f0ca1dd8257b5202eede04019b4415f491351"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e8aeefebe752f46e3c4b769e53f1d4ad71208fe1150975ef7662c22cca80fab"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b7e4e4dd177a8665c9ce86bc9caae2ab3aa9360b7ce7ec01827ea1baea9ff748"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fc2915949e5c1ea27a851f7a472a7da7d0a40d679f0a31e42f1022f3c562e87"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a1fa38a4687b14f517f049477178093c39c2a10fdcced21116f47c017516498f"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5be8292d07a3ab828dc95b5ee6b69ca0a5b2e579a577b39671f4f5b47116dfd2"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:778588ca9897b6c6bab39b0d3034efff4c5438f5e3bd52fda3914175498202f9"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f0d5b3af045a187aedbd7ed5fc513bd933a97aaff78e61c3745b330792c4345b"},
+    {file = "psycopg_binary-3.2.9-cp313-cp313-win_amd64.whl", hash = "sha256:2290bc146a1b6a9730350f695e8b670e1d1feb8446597bed0bbe7c3c30e0abcb"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df22ec17390ec5ccb38d211fb251d138d37a43344492858cea24de8efa15003"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eac3a6e926421e976c1c2653624e1294f162dc67ac55f9addbe8f7b8d08ce603"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf789be42aea5752ee396d58de0538d5fcb76795c85fb03ab23620293fb81b6f"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0f05b9dafa5670a7503abc715af081dbbb176a8e6770de77bccaeb9024206c5"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2d7a6646d41228e9049978be1f3f838b557a1bde500b919906d54c4390f5086"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a4d76e28df27ce25dc19583407f5c6c6c2ba33b443329331ab29b6ef94c8736d"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:418f52b77b715b42e8ec43ee61ca74abc6765a20db11e8576e7f6586488a266f"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:1f1736d5b21f69feefeef8a75e8d3bf1f0a1e17c165a7488c3111af9d6936e91"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:5918c0fab50df764812f3ca287f0d716c5c10bedde93d4da2cefc9d40d03f3aa"},
+    {file = "psycopg_binary-3.2.9-cp38-cp38-win_amd64.whl", hash = "sha256:7b617b81f08ad8def5edd110de44fd6d326f969240cc940c6f6b3ef21fe9c59f"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:587a3f19954d687a14e0c8202628844db692dbf00bba0e6d006659bf1ca91cbe"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:791759138380df21d356ff991265fde7fe5997b0c924a502847a9f9141e68786"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95315b8c8ddfa2fdcb7fe3ddea8a595c1364524f512160c604e3be368be9dd07"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18ac08475c9b971237fcc395b0a6ee4e8580bb5cf6247bc9b8461644bef5d9f4"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac2c04b6345e215e65ca6aef5c05cc689a960b16674eaa1f90a8f86dfaee8c04"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1ab25e3134774f1e476d4bb9050cdec25f10802e63e92153906ae934578734"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4bfec4a73e8447d8fe8854886ffa78df2b1c279a7592241c2eb393d4499a17e2"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:166acc57af5d2ff0c0c342aed02e69a0cd5ff216cae8820c1059a6f3b7cf5f78"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:413f9e46259fe26d99461af8e1a2b4795a4e27cc8ac6f7919ec19bcee8945074"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:354dea21137a316b6868ee41c2ae7cce001e104760cf4eab3ec85627aed9b6cd"},
+    {file = "psycopg_binary-3.2.9-cp39-cp39-win_amd64.whl", hash = "sha256:24ddb03c1ccfe12d000d950c9aba93a7297993c4e3905d9f2c9795bb0764d523"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -1892,4 +1993,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "ac74976a5aa0d07fe64672c9f27e541d85d95044c9294a513db4daa63cfa7adf"
+content-hash = "bc7e3e20429a48cfe80cd38027eaee8c7ad5902b815131ee099f4d2cee465cc4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ alembic = "^1.16.4"
 click = "^8.2.1"
 pygithub = "^2.7.0"
 pydantic-settings = "^2.10.1"
+psycopg = {extras = ["binary"], version = "^3.2.9"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/sc_audit/cli.py
+++ b/sc_audit/cli.py
@@ -21,9 +21,11 @@ from sc_audit.loader.minted_blocks import load_minted_blocks
 from sc_audit.loader.retirement_from_block import load_retirement_from_block
 from sc_audit.loader.retirements import load_retirements
 from sc_audit.loader.sink_events import load_sink_events
+from sc_audit.loader.sink_invocations import load_sink_invocations
 from sc_audit.loader.sink_status import load_sink_statuses
 from sc_audit.loader.sinking_txs import load_sinking_txs
 from sc_audit.sources.sink_events import MercuryError
+from sc_audit.sources.sink_invocations import ObsrvrError
 from sc_audit.views.inventory import view_inventory
 from sc_audit.views.retirement import view_retirements
 from sc_audit.views.sink_status import view_sinking_txs
@@ -181,12 +183,21 @@ def db_load_sinking_txs():
     sink_cursor: int = get_latest_attr('sink_tx') # type: ignore[return-value]
     num_sinking_txs = load_sinking_txs(cursor=sink_cursor)
     click.echo(f"Loaded {num_sinking_txs} sinking transactions")
+
+    # TODO: separate classic and SinkContract txs
+    # attempt to load SinkContract txs from Obsrvr or Mercury
     try:
-        num_sink_events = load_sink_events(cursor=sink_cursor)
-        print(f"Loaded {num_sink_events} sink events")
-    except MercuryError as exc:
-        click.echo(f"Couldn't load sink events from Mercury")
+        num_sink_invocations = load_sink_invocations(cursor=sink_cursor)
+        print(f"Loaded {num_sink_invocations} sink invocations")
+    except ObsrvrError as exc:
+        click.echo(f"Couldn't load sink invocations from Obsrvr")
         click.echo(repr(exc), err=True)
+        try:
+            num_sink_events = load_sink_events(cursor=sink_cursor)
+            print(f"Loaded {num_sink_events} sink events")
+        except MercuryError as exc:
+            click.echo(f"Couldn't load sink events from Mercury")
+            click.echo(repr(exc), err=True)
 
 
 @load.command(name="retirements")

--- a/sc_audit/cli.py
+++ b/sc_audit/cli.py
@@ -182,7 +182,7 @@ def db_load_sinking_txs():
     num_sinking_txs = load_sinking_txs(cursor=sink_cursor)
     click.echo(f"Loaded {num_sinking_txs} sinking transactions")
     try:
-        num_sink_events, _ = load_sink_events(cursor=sink_cursor)
+        num_sink_events = load_sink_events(cursor=sink_cursor)
         print(f"Loaded {num_sink_events} sink events")
     except MercuryError as exc:
         click.echo(f"Couldn't load sink events from Mercury")

--- a/sc_audit/config.py
+++ b/sc_audit/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import HttpUrl, computed_field
+from pydantic import HttpUrl, PostgresDsn, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from stellar_sdk import Asset
 
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
     RETROSHADES_URL: HttpUrl = HttpUrl("https://api.mercurydata.app/retroshadesv1")
     RETROSHADES_MD5: str = "3dd6e7b71adb9fda05a5b45a154611f3"
     MERCURY_KEY: str = ""
+
+    OBSRVR_FLOW_DB_URI: PostgresDsn | None = None
+    OBSRVR_FLOW_TABLE: str = "extracted_contract_invocations"
 
     @computed_field
     @property

--- a/sc_audit/constants.py
+++ b/sc_audit/constants.py
@@ -1,0 +1,5 @@
+from decimal import Decimal
+
+
+KG = Decimal("0.001")
+UNIT_IN_STROOPS = Decimal(10_000_000)

--- a/sc_audit/loader/__main__.py
+++ b/sc_audit/loader/__main__.py
@@ -23,9 +23,11 @@ from sc_audit.loader.minted_blocks import load_minted_blocks
 from sc_audit.loader.retirement_from_block import load_retirement_from_block
 from sc_audit.loader.retirements import load_retirements
 from sc_audit.loader.sink_events import load_sink_events
+from sc_audit.loader.sink_invocations import load_sink_invocations
 from sc_audit.loader.sink_status import load_sink_statuses
 from sc_audit.loader.sinking_txs import load_sinking_txs
 from sc_audit.sources.sink_events import MercuryError
+from sc_audit.sources.sink_invocations import ObsrvrError
 
 
 def catch_up_from_sources():
@@ -51,12 +53,20 @@ def catch_up_from_sources():
     print(f"Loaded {num_distribution_txs} distribution outflows")
     num_sinking_txs = load_sinking_txs(cursor=sink_cursor)
     print(f"Loaded {num_sinking_txs} sinking transactions")
+    
+    # attempt to load SinkContract txs from Obsrvr or Mercury
     try:
-        num_sink_events = load_sink_events(cursor=sink_cursor)
-        print(f"Loaded {num_sink_events} sink events")
-    except MercuryError as exc:
-        print(f"Couldn't load sink events from Mercury")
+        num_sink_invocations = load_sink_invocations(cursor=sink_cursor)
+        print(f"Loaded {num_sink_invocations} sink invocations")
+    except ObsrvrError as exc:
+        print(f"Couldn't load sink invocations from Obsrvr")
         print(repr(exc), file=sys.stderr)
+        try:
+            num_sink_events = load_sink_events(cursor=sink_cursor)
+            print(f"Loaded {num_sink_events} sink events")
+        except MercuryError as exc:
+            print(f"Couldn't load sink events from Mercury")
+            print(repr(exc), file=sys.stderr)
         
     num_minting_txs = load_minted_blocks(cursor=mint_cursor)
     print(f"Loaded {num_minting_txs} minted blocks")

--- a/sc_audit/loader/__main__.py
+++ b/sc_audit/loader/__main__.py
@@ -52,7 +52,7 @@ def catch_up_from_sources():
     num_sinking_txs = load_sinking_txs(cursor=sink_cursor)
     print(f"Loaded {num_sinking_txs} sinking transactions")
     try:
-        num_sink_events, _ = load_sink_events(cursor=sink_cursor)
+        num_sink_events = load_sink_events(cursor=sink_cursor)
         print(f"Loaded {num_sink_events} sink events")
     except MercuryError as exc:
         print(f"Couldn't load sink events from Mercury")

--- a/sc_audit/loader/sink_events.py
+++ b/sc_audit/loader/sink_events.py
@@ -15,7 +15,7 @@ from sc_audit.session_manager import Session
 from sc_audit.sources.sink_events import get_sink_events
 
 
-def load_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> tuple[int, list[tuple[str, str]]]:
+def load_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
     """
     Load (all) sink events from Mercury Retroshades into the DB.
 
@@ -29,7 +29,6 @@ def load_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> tuple[int, list[
     separately.
     """
     number_loaded = 0
-    recipient_emails: dict[str, str] = {}
 
     with Session.begin() as session:
         last_ledger = 0
@@ -37,9 +36,6 @@ def load_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> tuple[int, list[
         # This is a pragmatic choice; ideally, the order should come from Retroshades.
         tx_order = first_tx_index = 2**16
         for sink_event in get_sink_events(cursor):
-            if sink_event.email:
-                recipient_emails[sink_event.recipient] = sink_event.email
-
             vcs_project_id = try_project_id(sink_event.project_id)
 
             # FIXME: the TOID should come from Retroshades if possible
@@ -78,7 +74,7 @@ def load_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> tuple[int, list[
         
         number_loaded = len(session.new)
 
-    return number_loaded, list(recipient_emails.items())
+    return number_loaded
 
 
 @lru_cache(maxsize=32)

--- a/sc_audit/loader/sink_invocations.py
+++ b/sc_audit/loader/sink_invocations.py
@@ -8,7 +8,7 @@ from sc_audit.config import settings
 from sc_audit.db_schema.sink import SinkingTx
 from sc_audit.loader.sink_events import try_project_id
 from sc_audit.session_manager import Session
-from sc_audit.sources.sink_invocations import get_sink_invocations
+from sc_audit.sources.sink_invocations import InvocationSource
 
 
 def load_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
@@ -23,7 +23,7 @@ def load_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
     number_loaded = 0
 
     with Session.begin() as session:
-        for sink_invoke in get_sink_invocations(cursor):
+        for sink_invoke in InvocationSource.get_sink_invocations(cursor):
             vcs_project_id = try_project_id(sink_invoke.project_id)
             memo = sink_invoke.memo_text or None
             session.add(

--- a/sc_audit/loader/sink_invocations.py
+++ b/sc_audit/loader/sink_invocations.py
@@ -15,8 +15,8 @@ def load_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
     """
     Load (all) sink invocations from Obsrvr Flow into the DB.
 
-    To catch up with Flow, specify the cursor parameter to be the incremented
-    paging token of the latest record present in the DB.
+    To catch up with Flow, specify the cursor parameter to be the paging token
+    of the latest sink invocation record present in the SinkingTx table.
 
     TODO: separate latest classic tx and SinkContract tx on the basis of contract_id. 
     """
@@ -29,17 +29,17 @@ def load_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
             session.add(
                 SinkingTx(
                     hash=sink_invoke.tx_hash,
-                    created_at=sink_invoke.created_at,
+                    created_at=sink_invoke.timestamp,
                     contract_id=sink_invoke.contract_id,
                     funder=sink_invoke.funder,
                     recipient=sink_invoke.recipient,
-                    carbon_amount=sink_invoke.amount,
+                    carbon_amount=sink_invoke.ton_amount,
                     source_asset_code=settings.CARBON_ASSET.code,
                     source_asset_issuer=settings.CARBON_ISSUER_PUB,
-                    source_asset_amount=sink_invoke.amount,
+                    source_asset_amount=sink_invoke.ton_amount,
                     dest_asset_code=settings.CARBON_ASSET.code,
                     dest_asset_issuer=settings.CARBON_ISSUER_PUB,
-                    dest_asset_amount=sink_invoke.amount,
+                    dest_asset_amount=sink_invoke.ton_amount,
                     vcs_project_id=vcs_project_id,
                     memo_type='text' if memo else 'none',
                     memo_value=memo,

--- a/sc_audit/loader/sink_invocations.py
+++ b/sc_audit/loader/sink_invocations.py
@@ -1,0 +1,52 @@
+"""
+Load sink invocations from sorocarbon into the DB as SinkingTx records.
+
+Author: Alex Olieman <https://keybase.io/alioli>
+"""
+
+from sc_audit.config import settings
+from sc_audit.db_schema.sink import SinkingTx
+from sc_audit.loader.sink_events import try_project_id
+from sc_audit.session_manager import Session
+from sc_audit.sources.sink_invocations import get_sink_invocations
+
+
+def load_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> int:
+    """
+    Load (all) sink invocations from Obsrvr Flow into the DB.
+
+    To catch up with Flow, specify the cursor parameter to be the incremented
+    paging token of the latest record present in the DB.
+
+    TODO: separate latest classic tx and SinkContract tx on the basis of contract_id. 
+    """
+    number_loaded = 0
+
+    with Session.begin() as session:
+        for sink_invoke in get_sink_invocations(cursor):
+            vcs_project_id = try_project_id(sink_invoke.project_id)
+            memo = sink_invoke.memo_text or None
+            session.add(
+                SinkingTx(
+                    hash=sink_invoke.tx_hash,
+                    created_at=sink_invoke.created_at,
+                    contract_id=sink_invoke.contract_id,
+                    funder=sink_invoke.funder,
+                    recipient=sink_invoke.recipient,
+                    carbon_amount=sink_invoke.amount,
+                    source_asset_code=settings.CARBON_ASSET.code,
+                    source_asset_issuer=settings.CARBON_ISSUER_PUB,
+                    source_asset_amount=sink_invoke.amount,
+                    dest_asset_code=settings.CARBON_ASSET.code,
+                    dest_asset_issuer=settings.CARBON_ISSUER_PUB,
+                    dest_asset_amount=sink_invoke.amount,
+                    vcs_project_id=vcs_project_id,
+                    memo_type='text' if memo else 'none',
+                    memo_value=memo,
+                    paging_token=sink_invoke.toid,
+                )
+            )
+        
+        number_loaded = len(session.new)
+
+    return number_loaded

--- a/sc_audit/sources/sink_events.py
+++ b/sc_audit/sources/sink_events.py
@@ -42,6 +42,12 @@ def get_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> list[SinkEvent]:
             mercury_key=settings.MERCURY_KEY,
             retroshades_md5=settings.RETROSHADES_MD5,
         )
+    elif settings.OBSRVR_FLOW_DB_URI:
+        raise MercuryError(
+            "Only one of MERCURY_KEY and OBSRVR_FLOW_DB_URI may be provided.",
+            mercury_key=settings.MERCURY_KEY,
+            retroshades_md5=settings.RETROSHADES_MD5,
+        )
 
     headers = {
         "Authorization": settings.MERCURY_KEY,

--- a/sc_audit/sources/sink_events.py
+++ b/sc_audit/sources/sink_events.py
@@ -5,15 +5,14 @@ Author: Alex Olieman <https://keybase.io/alioli>
 """
 
 import datetime as dt
-from decimal import Decimal
+from decimal import ROUND_DOWN, Decimal
 
 import httpx
 from pydantic import BaseModel
 from stellar_sdk.sep.toid import TOID
 
 from sc_audit.config import settings
-
-UNIT_IN_STROOPS = 10_000_000
+from sc_audit.constants import KG, UNIT_IN_STROOPS
 
 
 class SinkEvent(BaseModel):
@@ -30,7 +29,7 @@ class SinkEvent(BaseModel):
 
     @classmethod
     def from_raw(cls, **data):
-        data["amount"] = data["amount"] / UNIT_IN_STROOPS
+        data["amount"] = (data["amount"] / UNIT_IN_STROOPS).quantize(KG, rounding=ROUND_DOWN)
         data["created_at"] = dt.datetime.fromtimestamp(data["timestamp"], dt.UTC)
         return cls(**data)
 

--- a/sc_audit/sources/sink_invocations.py
+++ b/sc_audit/sources/sink_invocations.py
@@ -68,7 +68,7 @@ def get_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> Sequence[Sin
     query = select(SinkInvocation).where(SinkInvocation.toid > cursor)
     
     with Session(engine, expire_on_commit=False) as session:
-        invokes = session.execute(query).scalars().all()
+        invokes = session.scalars(query).all()
 
     return invokes
 

--- a/sc_audit/sources/sink_invocations.py
+++ b/sc_audit/sources/sink_invocations.py
@@ -1,0 +1,83 @@
+"""
+Fetch sink_carbon invocations from Obsrver Flow.
+
+Author: Alex Olieman <https://keybase.io/alioli>
+"""
+
+import datetime as dt
+from decimal import Decimal
+
+from pydantic import BaseModel
+from sqlalchemy import create_engine, make_url, select, Table, MetaData
+
+from sc_audit.config import settings
+
+
+UNIT_IN_STROOPS = 10_000_000
+
+
+class SinkInvocation(BaseModel):
+    id: int
+    toid: int
+    ledger: int
+    tx_hash: str
+    created_at: dt.datetime
+    contract_id: str
+    function_name: str
+    invoking_account: str
+    processed_at: dt.datetime
+    schema_name: str
+    successful: bool
+
+    funder: str
+    recipient: str
+    amount: Decimal
+    project_id: str
+    memo_text: str | None
+    email: str | None
+
+    @classmethod
+    def from_raw(cls, **data):
+        data["amount"] = data["amount"] / UNIT_IN_STROOPS
+        data["created_at"] = data["timestamp"]
+        return cls(**data)
+
+
+def get_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> list[SinkInvocation]:
+    if not settings.OBSRVR_FLOW_DB_URI:
+        raise ObsrvrError(
+             "Skip sink invocations: Obsrvr DB URI is not set in the configuration.",
+             dsn_uri=None
+        )
+    elif settings.MERCURY_KEY:
+        raise ObsrvrError(
+            "Only one of MERCURY_KEY and OBSRVR_FLOW_DB_URI may be provided.",
+            dsn_uri=str(settings.OBSRVR_FLOW_DB_URI)
+        )
+
+    db_url = make_url(str(settings.OBSRVR_FLOW_DB_URI))
+    engine = create_engine(db_url)
+    
+    with engine.begin() as conn:
+        metadata = MetaData()
+        sink_table = Table(
+            settings.OBSRVR_FLOW_TABLE,
+            metadata,
+            autoload_with=conn
+        )
+        result = conn.execute(
+            select(sink_table).where(sink_table.c.toid > cursor)
+        )    
+
+    return [SinkInvocation.from_raw(**row._mapping) for row in result]
+
+
+class ObsrvrError(Exception):
+    def __init__(self, msg, dsn_uri: str | None):
+        super().__init__(msg, dsn_uri)
+
+
+
+if __name__ == "__main__":
+    sink_events = get_sink_events(cursor=0)
+    pass

--- a/sc_audit/sources/sink_invocations.py
+++ b/sc_audit/sources/sink_invocations.py
@@ -43,7 +43,7 @@ class SinkInvocation(BaseModel):
         return cls(**data)
 
 
-def get_sink_events(cursor: int=settings.FIRST_SINK_CURSOR) -> list[SinkInvocation]:
+def get_sink_invocations(cursor: int=settings.FIRST_SINK_CURSOR) -> list[SinkInvocation]:
     if not settings.OBSRVR_FLOW_DB_URI:
         raise ObsrvrError(
              "Skip sink invocations: Obsrvr DB URI is not set in the configuration.",
@@ -79,5 +79,5 @@ class ObsrvrError(Exception):
 
 
 if __name__ == "__main__":
-    sink_events = get_sink_events(cursor=0)
+    sink_events = get_sink_invocations(cursor=0)
     pass

--- a/tests/data_fixtures/events.py
+++ b/tests/data_fixtures/events.py
@@ -112,7 +112,7 @@ query_response = """
   {
     "funder": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
     "recipient": "GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC",
-    "amount": 100000,
+    "amount": 109999,
     "project_id": "VCS1360",
     "memo_text": "testing",
     "email": "test@mock.dev",

--- a/tests/data_fixtures/invocations.py
+++ b/tests/data_fixtures/invocations.py
@@ -1,0 +1,70 @@
+import datetime as dt
+import zoneinfo
+
+from sc_audit.sources.sink_invocations import SinkInvocation
+
+
+gmt_zoneinfo = zoneinfo.ZoneInfo(key='GMT')
+
+items = [
+    SinkInvocation(
+        id=1,
+        toid=188328285796925850,
+        ledger=43848596,
+        timestamp=dt.datetime(2022, 12, 3, 15, 33, 35, tzinfo=gmt_zoneinfo),
+        contract_id='CAVS7HEUNFCMOW6DC7EBY7J6HNFJ5JJ7LV4H7RPUC6V5QO5OMS7AQLD5',
+        function_name='sink_carbon',
+        invoking_account='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        tx_hash='2f55d7e30d801908fc72f5f11cbf44b264fca73f6386117ebc6274f356affa71',
+        funder='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        recipient='GC53JCXZHW3SVNRE4CT6XFP46WX4ACFQU32P4PR3CU43OB7AKKMFXZ6Y',
+        amount=1000000,
+        project_id='VCS1360',
+        memo_text='one',
+        email='account@domain.xyz',
+        processed_at=dt.datetime(2025, 8, 24, 12, 28, 23, 38732, tzinfo=gmt_zoneinfo),
+        schema_name='carbon_sink_v1',
+        successful=True,
+        created_at=dt.datetime(2025, 8, 24, 12, 28, 23, 38732, tzinfo=gmt_zoneinfo)
+    ),
+    SinkInvocation(
+        id=2,
+        toid=188915296156604069,
+        ledger=43985272,
+        timestamp=dt.datetime(2022, 12, 12, 20, 50, 40, tzinfo=gmt_zoneinfo),
+        contract_id='CAVS7HEUNFCMOW6DC7EBY7J6HNFJ5JJ7LV4H7RPUC6V5QO5OMS7AQLD5',
+        function_name='sink_carbon',
+        invoking_account='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        tx_hash='1b2aed0644c8fab9abff84aee78e7f0b92b09a8cf9bd2c1a17e71964c768a805',
+        funder='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        recipient='GC53JCXZHW3SVNRE4CT6XFP46WX4ACFQU32P4PR3CU43OB7AKKMFXZ6Y',
+        amount=3330000,
+        project_id='VCS1360',
+        memo_text='two',
+        email='account@domain.xyz',
+        processed_at=dt.datetime(2025, 8, 24, 12, 29, 59, 73393, tzinfo=gmt_zoneinfo),
+        schema_name='carbon_sink_v1',
+        successful=True,
+        created_at=dt.datetime(2025, 8, 24, 12, 29, 59, 73393, tzinfo=gmt_zoneinfo)
+    ),
+    SinkInvocation(
+        id=3,
+        toid=2209834166299873287,
+        ledger=348855824,
+        timestamp=dt.datetime(2025, 8, 24, 12, 30, 32, tzinfo=gmt_zoneinfo),
+        contract_id='CAVS7HEUNFCMOW6DC7EBY7J6HNFJ5JJ7LV4H7RPUC6V5QO5OMS7AQLD5',
+        function_name='sink_carbon',
+        invoking_account='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        tx_hash='e7d68ab7c57e38e2e103b81926db97731eb9ca861de5282eaf1bcc97e1605deb',
+        funder='GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL',
+        recipient='GC53JCXZHW3SVNRE4CT6XFP46WX4ACFQU32P4PR3CU43OB7AKKMFXZ6Y',
+        amount=4444444,
+        project_id='VCS1360',
+        memo_text='tri',
+        email='account@domain.xyz',
+        processed_at=dt.datetime(2025, 8, 24, 12, 30, 34, 920249, tzinfo=gmt_zoneinfo),
+        schema_name='carbon_sink_v1',
+        successful=True,
+        created_at=dt.datetime(2025, 8, 24, 12, 30, 34, 920249, tzinfo=gmt_zoneinfo)
+    ),
+]

--- a/tests/data_fixtures/invocations.py
+++ b/tests/data_fixtures/invocations.py
@@ -6,8 +6,9 @@ from sc_audit.sources.sink_invocations import SinkInvocation
 
 gmt_zoneinfo = zoneinfo.ZoneInfo(key='GMT')
 
-items = [
-    SinkInvocation(
+def get_items() -> list[SinkInvocation]:
+    return [
+        SinkInvocation(
         id=1,
         toid=188328285796925850,
         ledger=43848596,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -75,11 +75,8 @@ def mock_session(monkeypatch, new_session):
 @pytest.mark.usefixtures("mock_client", "patch_mercury_key")
 class TestSinkEventLoader:
     def test_load_sink_events(self, mock_session):
-        num_loaded, emails = event_loader.load_sink_events(cursor=0)
+        num_loaded = event_loader.load_sink_events(cursor=0)
         assert num_loaded == 10
-        assert len(emails) == 7
-        assert emails[0] == ('GAN4FQZL5P7B7OGW4KMYA6B2V34W7E6C7NL7K4P6ZNNWQ6UZD6I7GABC', 'test@mock.dev')
-        assert emails[-1] == ('GBBXYZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ99', 'gift@giver.org')
 
         with mock_session.begin() as session:
             loaded_events = session.scalars(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -45,6 +45,7 @@ def mock_client(monkeypatch):
 
 @pytest.fixture
 def patch_mercury_key(patch_settings):
+    patch_settings.OBSRVR_FLOW_DB_URI = None
     if not patch_settings.MERCURY_KEY:
         patch_settings.MERCURY_KEY = "123456789ABCDEFGHJKLMNPQRSTUVWXY"
 

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -1,0 +1,155 @@
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from sc_audit.db_schema.sink import SinkingTx
+from sc_audit.loader import impact_projects
+from sc_audit.loader import sink_invocations as invocation_loader
+from sc_audit.loader import sinking_txs as sink_loader
+from sc_audit.sources import sink_invocations as invocation_source
+from tests.db_fixtures import engine, new_session
+from tests.data_fixtures import invocations
+from tests.test_settings import patch_settings
+from tests.test_sink import mock_http
+
+
+@pytest.fixture
+def patch_flow_db_engine(monkeypatch, patch_settings):
+    patch_settings.MERCURY_KEY = ""
+    patch_settings.OBSRVR_FLOW_DB_URI = engine.url
+    monkeypatch.setattr(invocation_source, 'engine', engine)
+
+
+@pytest.fixture
+def mock_invocations():
+    invocation_source.SinkInvocation.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        session.add_all(invocations.items)
+        session.commit()
+
+    yield
+
+    invocation_source.SinkInvocation.metadata.drop_all(engine)
+
+
+
+@pytest.mark.usefixtures("mock_invocations", "patch_flow_db_engine")
+class TestSinkInvocationSource:
+    def test_invoke_list_full(self):
+        invokes = invocation_source.get_sink_invocations(cursor=0)
+        assert len(invokes) == 3
+        one, two, tri = invokes
+
+        assert all(
+            inv.contract_id == "CAVS7HEUNFCMOW6DC7EBY7J6HNFJ5JJ7LV4H7RPUC6V5QO5OMS7AQLD5"
+            for inv in invokes
+        )
+        assert all(
+            inv.function_name == "sink_carbon"
+            for inv in invokes
+        )
+        assert all(
+            inv.invoking_account == "GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL"
+            for inv in invokes
+        )
+        assert all(
+            inv.funder == "GAN4SL6DHOQO4POKWOUL4PPCIVJBSDX7SVOLL4GVM4CC27S6WCV7FQZL"
+            for inv in invokes
+        )
+        assert all(
+            inv.recipient == "GC53JCXZHW3SVNRE4CT6XFP46WX4ACFQU32P4PR3CU43OB7AKKMFXZ6Y"
+            for inv in invokes
+        )
+        assert all(
+            inv.project_id == "VCS1360"
+            for inv in invokes
+        )
+
+        assert one.toid == 188328285796925850
+        assert one.tx_hash == "2f55d7e30d801908fc72f5f11cbf44b264fca73f6386117ebc6274f356affa71"
+        assert one.amount == 1000000
+        assert one.ton_amount == Decimal("0.1")
+        assert one.memo_text == "one"
+
+        assert two.toid == 188915296156604069
+        assert two.tx_hash == "1b2aed0644c8fab9abff84aee78e7f0b92b09a8cf9bd2c1a17e71964c768a805"
+        assert two.amount == 3330000
+        assert two.ton_amount == Decimal("0.333")
+        assert two.memo_text == "two"
+
+        assert tri.toid == 2209834166299873287
+        assert tri.tx_hash == "e7d68ab7c57e38e2e103b81926db97731eb9ca861de5282eaf1bcc97e1605deb"
+        assert tri.amount == 4444444
+        assert tri.ton_amount == Decimal("0.444")
+        assert tri.memo_text == "tri"
+
+
+
+@pytest.fixture
+def mock_session(monkeypatch, new_session):
+    monkeypatch.setattr(impact_projects, 'Session', new_session)
+    monkeypatch.setattr(invocation_loader, 'Session', new_session)
+    monkeypatch.setattr(sink_loader, 'Session', new_session)
+    impact_projects.load_impact_projects()
+    return new_session
+
+
+@pytest.mark.usefixtures("mock_invocations", "patch_flow_db_engine")
+class TestSinkEventLoader:
+    def test_load_sink_events(self, mock_session):
+        num_loaded = invocation_loader.load_sink_invocations(cursor=0)
+        assert num_loaded == 3
+
+        with mock_session.begin() as session:
+            loaded_invocations = session.scalars(
+                select(SinkingTx).order_by(SinkingTx.paging_token.asc())
+                .options(joinedload(SinkingTx.vcs_project))
+            ).all()
+
+            assert all(
+                tx.contract_id == "CAVS7HEUNFCMOW6DC7EBY7J6HNFJ5JJ7LV4H7RPUC6V5QO5OMS7AQLD5"
+                for tx in loaded_invocations
+            )
+            assert all(
+                tx.carbon_amount == tx.source_asset_amount == tx.dest_asset_amount
+                for tx in loaded_invocations
+            )
+            assert all(
+                "CARBON" == tx.source_asset_code == tx.dest_asset_code
+                for tx in loaded_invocations
+            )
+            assert all(
+                tx.vcs_project and tx.vcs_project_id == 1360
+                for tx in loaded_invocations
+            )
+
+            memos = [tx.memo_value for tx in loaded_invocations]
+            assert memos == ["one", "two", "tri"]
+
+    def test_load_sink_txs_and_events(self, mock_http, mock_session):
+        sink_loader.load_sinking_txs(cursor=999)
+        invocation_loader.load_sink_invocations(cursor=999)
+
+        with mock_session.begin() as session:
+            loaded_transactions = session.scalars(
+                select(SinkingTx).order_by(SinkingTx.paging_token.asc())
+            ).all()
+            assert len(loaded_transactions) == 23
+            
+            prev_tx = None
+            cumulative_amount = Decimal(0)
+            # Invocations and classic txs are interleaved in the DB
+            for tx in loaded_transactions:
+                if prev_tx:
+                    # is the created_at time in accordance with the paging token?
+                    assert tx.created_at >= prev_tx.created_at
+                    # is each paging token unique?
+                    assert tx.paging_token != prev_tx.paging_token
+
+                prev_tx = tx
+                cumulative_amount += tx.carbon_amount
+
+            assert cumulative_amount == Decimal("27.175")


### PR DESCRIPTION
We don't want to rely on Mercury as the only source of sorocarbon sinking events. This PR adds the flexibility to use either Mercury Retroshades or Obsrvr Flow to load sinking transactions that originate in Soroban function calls.